### PR TITLE
Fix potential OOB read in sdpu_get_len_from_type

### DIFF
--- a/stack/sdp/sdp_db.c
+++ b/stack/sdp/sdp_db.c
@@ -129,7 +129,12 @@ static BOOLEAN find_uuid_in_seq (UINT8 *p , UINT32 seq_len, UINT8 *p_uuid,
     while (p < p_end)
     {
         type = *p++;
-        p = sdpu_get_len_from_type (p, type, &len);
+        p = sdpu_get_len_from_type(p, p_end, type, &len);
+        if (p == NULL || (p + len) > p_end)
+        {
+            SDP_TRACE_WARNING("%s: bad length", __func__);
+            break;
+        }
         type = type >> 3;
         if (type == UUID_DESC_TYPE)
         {

--- a/stack/sdp/sdp_utils.c
+++ b/stack/sdp/sdp_utils.c
@@ -637,7 +637,8 @@ UINT8 *sdpu_extract_attr_seq (UINT8 *p, UINT16 param_len, tSDP_ATTR_SEQ *p_seq)
 ** Returns          void
 **
 *******************************************************************************/
-UINT8 *sdpu_get_len_from_type (UINT8 *p, UINT8 type, UINT32 *p_len)
+UINT8 *sdpu_get_len_from_type (UINT8 *p, UINT8 *p_end, UINT8 type,
+                               UINT32 *p_len)
 {
     UINT8   u8;
     UINT16  u16;
@@ -661,14 +662,29 @@ UINT8 *sdpu_get_len_from_type (UINT8 *p, UINT8 type, UINT32 *p_len)
         *p_len = 16;
         break;
     case SIZE_IN_NEXT_BYTE:
+        if (p + 1 > p_end)
+        {
+            *p_len = 0;
+            return NULL;
+        }
         BE_STREAM_TO_UINT8 (u8, p);
         *p_len = u8;
         break;
     case SIZE_IN_NEXT_WORD:
+        if (p + 2 > p_end)
+        {
+            *p_len = 0;
+            return NULL;
+        }
         BE_STREAM_TO_UINT16 (u16, p);
         *p_len = u16;
         break;
     case SIZE_IN_NEXT_LONG:
+        if (p + 4 > p_end)
+        {
+            *p_len = 0;
+            return NULL;
+        }
         BE_STREAM_TO_UINT32 (u32, p);
         *p_len = (UINT16) u32;
         break;

--- a/stack/sdp/sdpint.h
+++ b/stack/sdp/sdpint.h
@@ -284,7 +284,7 @@ extern void      sdpu_build_n_send_error (tCONN_CB *p_ccb, UINT16 trans_num, UIN
 extern UINT8    *sdpu_extract_attr_seq (UINT8 *p, UINT16 param_len, tSDP_ATTR_SEQ *p_seq);
 extern UINT8    *sdpu_extract_uid_seq (UINT8 *p, UINT16 param_len, tSDP_UUID_SEQ *p_seq);
 
-extern UINT8    *sdpu_get_len_from_type (UINT8 *p, UINT8 type, UINT32 *p_len);
+extern UINT8    *sdpu_get_len_from_type (UINT8 *p, UINT8 *p_end, UINT8 type, UINT32 *p_len);
 extern BOOLEAN  sdpu_is_base_uuid (UINT8 *p_uuid);
 extern BOOLEAN  sdpu_compare_uuid_arrays (UINT8 *p_uuid1, UINT32 len1, UINT8 *p_uuid2, UINT16 len2);
 extern BOOLEAN  sdpu_compare_bt_uuids (tBT_UUID *p_uuid1, tBT_UUID *p_uuid2);


### PR DESCRIPTION
Add boundary check in sdpu_get_len_from_type to prevent potential OOB read.

Bug: 117105007
Test: Manul
Merged-In: I3755e13ee0a7e22ffd5f48fca909610a26b09d0a
Change-Id: I3755e13ee0a7e22ffd5f48fca909610a26b09d0a
(cherry picked from commit 1243f8da338dadfe2a3c281a08297b431402d41c)
(cherry picked from commit 4d8e1d63e1a2116c47702d38d858f5a742e8292f)